### PR TITLE
Updated layout_height on List Layouts

### DIFF
--- a/app/src/main/res/layout/example_list_item.xml
+++ b/app/src/main/res/layout/example_list_item.xml
@@ -2,7 +2,7 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+     android:layout_height="wrap_content"
     android:background="@drawable/list_item_background"
     >
     <TextView

--- a/app/src/main/res/layout/string_list_item.xml
+++ b/app/src/main/res/layout/string_list_item.xml
@@ -2,7 +2,7 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:background="@drawable/list_item_background"
     >
 


### PR DESCRIPTION
Replaced android:layout_height="**match_paren**t" with android:layout_height="**wrap_content**" for the Recycleview to display all items in the list.